### PR TITLE
Set PresetButton label by applying the subnet mask

### DIFF
--- a/src/widgets.py
+++ b/src/widgets.py
@@ -70,8 +70,11 @@ class PresetButton(Gtk.Button):
     def __init__(self, preset_range, tooltip_text, callback=None):
         super().__init__()
 
-        display_text = preset_range.split('/')[0].replace('.0', '.x')
-        self.set_label(display_text)
+        ip_address = preset_range.split("/")[0].split(".")
+        prefix_length = int(preset_range.split("/")[1]) // 8
+        ip_address[prefix_length:] = ["x" for _ in range(4 - prefix_length)]
+
+        self.set_label(".".join(ip_address))
         self.set_tooltip_text(_(tooltip_text))
         self.add_css_class("pill")
 


### PR DESCRIPTION
Hi,
the previous way of determining the label for the `PresetButton`s by replacing zeros does not work right with addresses which contain wanted zeros like `10.0.0.0/24` (24 subnet) or `10.0.12.0/24`.
I noticed the first one on all but the first example in the app where labels do neither correspond with the set values nor with the tooltips.